### PR TITLE
Expose the renderScene method on api

### DIFF
--- a/index.js
+++ b/index.js
@@ -292,8 +292,8 @@ module.exports = function createLogo (options_) {
     }
   })
 
-  function renderScene () {
-    if (!shouldRender) return
+  function renderScene (externallyTriggeredRerender) {
+    if (!externallyTriggeredRerender && !shouldRender) return
     window.requestAnimationFrame(renderScene)
 
     var li = (1.0 - lookRate)
@@ -317,5 +317,6 @@ module.exports = function createLogo (options_) {
     setFollowMotion: setFollowMotion,
     stopAnimation: stopAnimation,
     startAnimation: startAnimation,
+    renderScene: renderScene,
   }
 }


### PR DESCRIPTION
This PR exposes the `renderScene` method, and adds a parameter to it, to allow users of the `createLogo` method to trigger a rerender. This is useful in cases where the user wishes to programatically set where the fox is looking, via the `lookAt` method, without mouse movement.