### PR TITLE
Revert 0b3b42c ('Expose the renderScene method on api' / PR #28)

### DIFF
--- a/index.js
+++ b/index.js
@@ -292,8 +292,8 @@ module.exports = function createLogo (options_) {
     }
   })
 
-  function renderScene (externallyTriggeredRerender) {
-    if (!externallyTriggeredRerender && !shouldRender) return
+  function renderScene () {
+    if (!shouldRender) return
     window.requestAnimationFrame(renderScene)
 
     var li = (1.0 - lookRate)
@@ -317,6 +317,5 @@ module.exports = function createLogo (options_) {
     setFollowMotion: setFollowMotion,
     stopAnimation: stopAnimation,
     startAnimation: startAnimation,
-    renderScene: renderScene,
   }
 }


### PR DESCRIPTION
This PR removes a bug with https://github.com/MetaMask/metamask-logo/pull/28 

The bug in that PR was caused by adding a parameter to the `renderScene` method which, if truthy, would override the internal check for whether a render should occur (i.e. whether or not the `shouldRender` variable is true). The problem with that change is that `renderScene` passes itself to `window.requestAnimationFrame`, which accepts a callback and passes that callback a truthy  parameter (a timestamp). **This effectively causes an infinite loop of calls to `renderScene`.**

 That parameter is removed in this PR, and the render scene method is reverted to its pre #28 version.