### PR TITLE
Add lookAtAndRender method

### DIFF
--- a/index.js
+++ b/index.js
@@ -292,6 +292,18 @@ module.exports = function createLogo (options_) {
     }
   })
 
+  function lookAtAndRender (target) {
+    setLookAt(target)
+
+    lookCurrent[0] = mouse.x
+    lookCurrent[1] = mouse.y + (0.085 / lookRate)
+
+    var matrix = computeMatrix()
+    updatePositions(matrix)
+    updateFaces()
+    stopAnimation()
+  }
+
   function renderScene () {
     if (!shouldRender) return
     window.requestAnimationFrame(renderScene)
@@ -317,5 +329,6 @@ module.exports = function createLogo (options_) {
     setFollowMotion: setFollowMotion,
     stopAnimation: stopAnimation,
     startAnimation: startAnimation,
+    lookAtAndRender: lookAtAndRender,
   }
 }


### PR DESCRIPTION
This PR contains a commit from #29 and should be rebased and merged after #29 is merged.

This PR aims to do what #28 was meant to do:
> to allow users of the createLogo method to trigger a rerender. This is useful in cases where the user wishes to programatically set where the fox is looking...

#28 did this by providing access to the `renderScene` method, so that a render could be trigger after a `lookAt` call was made. That turned out to be buggy for reasons explained in #29 

This PR provides a better solution: the `lookAtAndRender` method.

This method causes the fox to immediately look at the target provided.

The existing `renderScene` method updates where the fox is looking via a recursive calculation:
```
lookCurrent[0] = li * lookCurrent[0] + lookRate * mouse.x
lookCurrent[1] = li * lookCurrent[1] + lookRate * mouse.y + 0.085
```

So, where the fox will be looking after any `renderScene` call is dependent on where the fox was looking before the `renderScene` call. In the case of following the mouse, it is sufficient for the calculation to only only happen one time, or a small number of times (multiple times can happen because `renderScene` is passed to `requestAnimationFrame`), for each `'mousemove'` event.

However, when pointing the fox at a specific location at an noticeable distance from where it is currently looking, this is insufficient. `renderScene` would need to be called enough times for the `lookCurrent` coordinates to approximate the appropriate `mouse` coordinates.

The new `lookAtAndRender` method directly points the fox at the correct coordinates. These coordinates are the coordinates that would be reached if the number of calls of recursive calculation above approaches infinity. Or, more simply, the mouse coordinates with `0.085 / lookRate` added to the y coordinate. (`0.085` was a value introduced to the renderScene calculation of the y coordinate to look at in https://github.com/MetaMask/metamask-logo/commit/d746ac6f9118e4d6945a1444505550fe4902d684)

This new method is put into use in metamask-extension https://github.com/MetaMask/metamask-extension/pull/9166

A demo of what it enables is below:

<img src="https://user-images.githubusercontent.com/7499938/90318850-e8b58300-df0d-11ea-956d-330219fc3fab.gif" width="300">  