### PR TITLE
Specify publish files

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "convert": "node convert.js > fox.json"
   },
   "files": [
+    "bundle.js",
     "fox.json"
   ],
   "author": "MetaMask",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "build": "browserify example/example.js -g uglifyify -o bundle.js",
     "convert": "node convert.js > fox.json"
   },
+  "files": [
+    "bundle.js"
+  ],
   "author": "MetaMask",
   "license": "ISC",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "convert": "node convert.js > fox.json"
   },
   "files": [
-    "bundle.js"
+    "fox.json"
   ],
   "author": "MetaMask",
   "license": "ISC",


### PR DESCRIPTION
Specify that only `bundle.js` and `fox.json` should be published beyond the defaults.

Not 100% sure if this is correct, cc: @danfinlay 