### PR TITLE
@metamask/eslint config@3.2.0

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,8 +20,5 @@ module.exports = {
   ],
   rules: {
     'no-bitwise': 'off',
-    'prefer-destructuring': [
-      'error', { 'array': false, 'object': true },
-    ],
   },
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "gl-vec3": "1.0.3"
   },
   "devDependencies": {
-    "@metamask/eslint-config": "^3.1.0",
+    "@metamask/eslint-config": "^3.2.0",
     "browserify": "^16.5.2",
     "copy-to-clipboard": "^3.0.5",
     "eslint": "^7.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@metamask/eslint-config@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-3.1.0.tgz#8412ddd3f660748598902fd8dbef6fadc060f25e"
-  integrity sha512-He/zV0Cb5W421mEQveaqSegLarONJbJPReJppQkwhi239PCE7j+6eRji/j2Unwq8TBuOlgQtqL49+dtvks+lPQ==
+"@metamask/eslint-config@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-3.2.0.tgz#66b9b2bea1616821506501e76de4ac991f34914f"
+  integrity sha512-WKfB81fD5NZBFbj/UqMyfNss/b25XrukVC3j2mcaIEF0uzSKzh1b/yy7aXxcfXshWemHz28MOwZT9Bin5KV37w==
 
 "@types/color-name@^1.1.1":
   version "1.1.1"


### PR DESCRIPTION
- `@metamask/eslint config@3.2.0`
- Remove local `prefer-destructuring` config, which is now handled by the config package