### PR TITLE
Rename package @metamask/logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Metamask Logo
 
-A browserifyable 3d metamask logo. [Live demo](http://metamask.github.io/metamask-logo/).
+A browserifyable 3d metamask logo. [Live demo](http://metamask.github.io/MetaMask/logo/).
 
 This repo can both be included as a browserifiable module, and includes a sample app.
 
@@ -8,11 +8,12 @@ The sample app address is `index.html`.
 The sample app javascript is `bundle.js`, which is built from `sample.js` using the `build` task (see the `package.json`).
 
 ## API
+
 ```javascript
-var ModelViewer = require('metamask-logo')
+const ModelViewer = require('@metamask/logo')
 
 // To render with fixed dimensions:
-var viewer = ModelViewer({
+const viewer = ModelViewer({
 
   // Dictates whether width & height are px or multiplied
   pxNotRatio: true,
@@ -31,7 +32,7 @@ var viewer = ModelViewer({
 })
 
 // add viewer to DOM
-var container = document.getElementById('logo-container')
+const container = document.getElementById('logo-container')
 container.appendChild(viewer.container)
 
 // look at something on the page

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "metamask-logo",
+  "name": "@metamask/logo",
   "version": "2.5.0",
-  "description": "A browserifyable 3d metamask logo. [Live demo](http://metamask.github.io/metamask-logo/).",
+  "description": "A browserifyable 3d metamask logo. [Live demo](http://metamask.github.io/logo/).",
   "main": "index.js",
   "scripts": {
     "build": "browserify example/example.js -g uglifyify -o bundle.js",
@@ -30,10 +30,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/MetaMask/metamask-logo.git"
+    "url": "git+https://github.com/MetaMask/logo.git"
   },
   "bugs": {
-    "url": "https://github.com/MetaMask/metamask-logo/issues"
+    "url": "https://github.com/MetaMask/logo/issues"
   },
-  "homepage": "https://github.com/MetaMask/metamask-logo#readme"
+  "homepage": "https://github.com/MetaMask/logo#readme"
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "bundle.js",
     "fox.json"
   ],
+  "private": false,
   "author": "MetaMask",
   "license": "ISC",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "bundle.js",
     "fox.json"
   ],
-  "private": false,
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
   "author": "MetaMask",
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
This will be followed by publishing the renamed package, a renaming of the repository to `logo`, and the deprecation of `metamask-logo`.